### PR TITLE
fix: making import-letters artisan command tenant-aware

### DIFF
--- a/app/Imports/LettersImport.php
+++ b/app/Imports/LettersImport.php
@@ -14,9 +14,8 @@ class LettersImport
     /**
      * @throws FileNotFoundException
      */
-    public function import(): string
+    public function import($prefix): string
     {
-
         if (!Storage::disk('local')->exists('imports/letter.json')) {
             return 'Soubor neexistuje';
         }
@@ -26,6 +25,14 @@ class LettersImport
 
         if (!$letters) {
             return 'Chyba při dekódování JSON';
+        }
+
+        $tenantId = DB::table('tenants')->where('table_prefix', $prefix)->value('id');
+
+        if (!$tenantId) {
+            return 'Tenant s prefixem "' . $prefix . '" neexistuje';
+        } else {
+            tenancy()->initialize($tenantId);
         }
 
         $importCount = 0;

--- a/routes/console.php
+++ b/routes/console.php
@@ -46,8 +46,8 @@ Artisan::command('hiko:import-identities', function () {
     $this->comment((new IdentitiesImport)->import());
 })->purpose('Import identities from previous version');
 
-Artisan::command('hiko:import-letters', function () {
-    $this->comment((new LettersImport)->import());
+Artisan::command('hiko:import-letters {prefix}', function ($prefix) {
+    $this->comment((new LettersImport)->import($prefix));
 })->purpose('Import letters from previous version');
 
 Artisan::command('hiko:import-media', function () {


### PR DESCRIPTION
Lze volat napr. `hiko:import-letters kalivoda` coz provede hromadny import (bulk import) dopisů z `.json` souboru do DB pro tenanta kalivoda.historicka-korespondence.cz